### PR TITLE
train_dev_test split: use bilingual file to create df

### DIFF
--- a/filtering/filter.py
+++ b/filtering/filter.py
@@ -16,11 +16,9 @@ import sys
 #from IPython.display import display
 
 
-def prepare(source_file, target_file, source_lang, target_lang, lower=False):
+def prepare(bilingual_file, source_lang, target_lang, lower=False):
     
-    df_source = pd.read_csv(source_file, names=['Source'], sep="\n", quoting=csv.QUOTE_NONE, skip_blank_lines=False, on_bad_lines="skip")
-    df_target = pd.read_csv(target_file, names=['Target'], sep="\n", quoting=csv.QUOTE_NONE, skip_blank_lines=False, on_bad_lines="skip")
-    df = pd.concat([df_source, df_target], axis=1)  # Join the two dataframes along columns
+    df = pd.read_csv(bilingual_file, names=['Source', 'Target'], sep="\t", quoting=csv.QUOTE_NONE, skip_blank_lines=False, on_bad_lines="skip")
     print("Dataframe shape (rows, columns):", df.shape)
 
     
@@ -109,8 +107,8 @@ def prepare(source_file, target_file, source_lang, target_lang, lower=False):
 
 
     # Write the dataframe to two Source and Target files
-    source_file = source_file+'-filtered.'+source_lang
-    target_file = target_file+'-filtered.'+target_lang
+    source_file = f"{bilingual_file}.{source_lang}-filtered.{source_lang}"
+    target_file = f"{bilingual_file}.{target_lang}-filtered.{target_lang}"
 
 
     # Save source and target to two text files
@@ -124,11 +122,10 @@ def prepare(source_file, target_file, source_lang, target_lang, lower=False):
 
 
 # Corpora details
-source_file = sys.argv[1]    # path to the source file
-target_file = sys.argv[2]    # path to the target file
-source_lang = sys.argv[3]    # source language
-target_lang = sys.argv[4]    # target language
+bilingual_file = sys.argv[1]
+source_lang = sys.argv[2]    # source language
+target_lang = sys.argv[3]    # target language
 
 # Run the prepare() function
 # Data will be true-case; change to True to lower-case
-prepare(source_file, target_file, source_lang, target_lang, lower=False)
+prepare(bilingual_file, source_lang, target_lang, lower=False)

--- a/train_dev_split/train_dev_test_split.py
+++ b/train_dev_split/train_dev_test_split.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Splitting the parallel dataset into train, development and test datasets for Machine Translation
-# Command: python3 train_dev_split.py <dev_segment_number> <test_segment_number> <source_file_path> <target_file_path>
+# Command: python3 train_dev_split.py <dev_segment_number> <test_segment_number> <bilingual_file_path> <source_lang> <target_lang>
 
 
 import pandas as pd
@@ -17,15 +17,14 @@ import sys
 
 segment_no_dev = sys.argv[1]    # Number of segments in the dev set
 segment_no_test = sys.argv[2]    # Number of segments in the test set
-source_file = sys.argv[3]   # Path to the source file
-target_file = sys.argv[4]   # Path to the target file
+bilingual_file = sys.argv[3]   # Path to the bilingual file
+source_lang = sys.argv[4]    # source language
+target_lang = sys.argv[5]    # target language
 
 
-def extract_dev(segment_no_dev, segment_no_test, source_file, target_file):
+def extract_dev(segment_no_dev, segment_no_test, bilingual_file, source_lang, target_lang):
 
-    df_source = pd.read_csv(source_file, names=['Source'], sep="\n", quoting=csv.QUOTE_NONE, error_bad_lines=False)
-    df_target = pd.read_csv(target_file, names=['Target'], sep="\n", quoting=csv.QUOTE_NONE, error_bad_lines=False)
-    df = pd.concat([df_source, df_target], axis=1)  # Join the two dataframes along columns
+    df = pd.read_csv(bilingual_file, names=['Source', 'Target'], sep="\t", quoting=csv.QUOTE_NONE, skip_blank_lines=False, on_bad_lines="skip")
     print("Dataframe shape:", df.shape)
 
 
@@ -44,14 +43,14 @@ def extract_dev(segment_no_dev, segment_no_test, source_file, target_file):
     df_train = df_train.drop(df_test.index)
 
     # Write the dataframe to two Source and Target files
-    source_file_train = source_file+'.train'
-    target_file_train = target_file+'.train'
+    source_file_train = f"{bilingual_file}.{source_lang}.train"
+    target_file_train = f"{bilingual_file}.{target_lang}.train"
 
-    source_file_dev = source_file+'.dev'
-    target_file_dev = target_file+'.dev'
+    source_file_dev = f"{bilingual_file}.{source_lang}.dev"
+    target_file_dev = f"{bilingual_file}.{target_lang}.dev"
 
-    source_file_test = source_file+'.test'
-    target_file_test = target_file+'.test'
+    source_file_test = f"{bilingual_file}.{source_lang}.test"
+    target_file_test = f"{bilingual_file}.{target_lang}.test"
 
     df_dic_train = df_train.to_dict(orient='list')
 
@@ -93,4 +92,4 @@ def extract_dev(segment_no_dev, segment_no_test, source_file, target_file):
 
 
 
-extract_dev(segment_no_dev, segment_no_test, source_file, target_file)
+extract_dev(segment_no_dev, segment_no_test, bilingual_file, source_lang, target_lang)


### PR DESCRIPTION
Same issue and similar solution as in https://github.com/ymoslem/MT-Preparation/pull/2, but this time for both scripts filter.py and train_dev_test_split.py

Here is how I implemented the change in the notebook 1-NMT-Data-Processing: 

```python
# Filter the dataset
!paste UN.en-fr.fr UN.en-fr.en > UN.en-fr
# Arguments: bilingual file, source file, target file, source language, target language
!python3 MT-Preparation/filtering/filter.py UN.en-fr fr en
```

```python
# Split the dataset into training set, development set, and test set
!paste UN.en-fr.fr-filtered.fr.subword UN.en-fr.en-filtered.en.subword > UN.en-fr.filtered.subword
# Development and test sets should be between 1000 and 5000 segments (here we chose 2000)
!python MT-Preparation/train_dev_split/train_dev_test_split.py 2000 2000 UN.en-fr.filtered.subword fr en
```